### PR TITLE
Add a parameterized pytest test with reporting to Qase

### DIFF
--- a/src/cake.py
+++ b/src/cake.py
@@ -1,7 +1,11 @@
 
 class Cake:
-    def __init__(self):
+    def __init__(self, flavor: str = "apple"):
         self._state = "uncooked"
+        self.flavor = flavor
+
+    def __str__(self):
+        return f"{self.flavor} cake, {self.state()}"
 
     def shake(self):
         if self._state == "uncooked":

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,5 +1,7 @@
-from cake import Cake
+import pytest
 from qaseio.pytest import qase
+
+from cake import Cake
 
 
 @qase.id(1)
@@ -58,3 +60,17 @@ def test_shake_a_cake():
         cake.bake()
         cake.take()
         assert cake.state() == "taken"
+
+
+@qase.id(15)
+@qase.title("Make parametrized cakes")
+@pytest.mark.parametrize("flavor, expected_str", [
+    ("cherry", "cherry cake, baked"),
+    ("chocolate", "chocolate cake, baked"),
+    ("strawberry", "strawberry cake, baked"),
+])
+def test_cake_str(flavor, expected_str):
+    cake = Cake(flavor=flavor)
+    cake.shake()
+    cake.bake()
+    assert str(cake) == expected_str

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -74,3 +74,32 @@ def test_cake_str(flavor, expected_str):
     cake.shake()
     cake.bake()
     assert str(cake) == expected_str
+
+
+# When we want to make a "parameterized" test, but match each variant
+# to a separate test case at Qase:
+def make_test_function(flavor, expected_str, qase_id):
+    # should have named it test_func,
+    # but then pytest would recognize it as a separate test
+    @qase.id(qase_id)
+    @qase.title(f"Make {flavor} cakes")
+    def func_test():
+        cake = Cake(flavor=flavor)
+        cake.shake()
+        cake.bake()
+        assert str(cake) == expected_str
+
+    func_test.__name__ = f"test_{flavor}_cake"
+    return func_test
+
+
+test_cases = [
+    ("cherry", "cherry cake, baked", 17),
+    ("chocolate", "chocolate cake, baked", 18),
+    ("strawberry", "strawberry cake, baked", 19)
+]
+
+# Dynamically create and add test functions to the global namespace
+for flavor, expected_str, qase_id in test_cases:
+    func_test = make_test_function(flavor, expected_str, qase_id)
+    globals()[func_test.__name__] = func_test


### PR DESCRIPTION
# Regular parameterized test

To add a parametrized test, we use the [`pytest.mark.parametrize` decorator](https://docs.pytest.org/en/6.2.x/parametrize.html) from pytest. Note that no additional decorators from `qase-pytest` are required, because it automatically recognizes a parameterized test and reports it correctly.

In a Qase test repository, this test looks like a single record:
<img width="414" alt="Screenshot 2024-02-07 at 15 56 37" src="https://github.com/cake-study/python/assets/8015154/4f82f640-75ae-4767-94d4-250af7a1a795">

But in a test run we can see three distinct parameterized tests:

<img width="644" alt="Screenshot 2024-02-07 at 15 54 42" src="https://github.com/cake-study/python/assets/8015154/01c0c833-9a23-4fb8-afba-6e92fc99a917">

# Parameterized test reporting to standalone test cases at Qase

To add such a case, we generate test functions dynamically, adding them to the `globals()` context and letting `pytest` discover them.

In a Qase test repository, these autotests match several distinct test cases:
<img width="683" alt="Screenshot 2024-02-07 at 16 03 47" src="https://github.com/cake-study/python/assets/8015154/51f595f6-205f-4c16-97de-f02e57198e58">

Of course, they're also distinct in a test run:
<img width="684" alt="Screenshot 2024-02-07 at 18 45 06" src="https://github.com/cake-study/python/assets/8015154/5ea3d88c-1338-43dc-85a1-c25e3e32e8db">
